### PR TITLE
Updating advance.jl

### DIFF
--- a/advance.jl
+++ b/advance.jl
@@ -4,29 +4,34 @@ function advance(burgers::Burgers)
     lastu = burgers.lastu
     lastv = burgers.lastv
     μ = burgers.μ
-    ν = burgers.ν
+    # ν = burgers.ν
     nx = burgers.nx
     ny = burgers.ny
+    dt = burgers.dt 
+    dx = burgers.dx
+    dy = burgers.dy
     rank = burgers.rank
     side = burgers.side
     for i in 2:(nx-1)
         for j in 2:(ny-1)
-            nextu[i,j] = lastu[i,j] - μ * (
-            lastu[i,j]*(lastu[i,j]-lastu[i-1,j]) -
-            lastv[i,j]*(lastu[i,j]-lastu[i,j-1])
+
+            nextu[i,j] = lastu[i,j] + dt * ( (
+            - lastu[i,j]/(2*dx)*(lastu[i+1,j]-lastu[i-1,j]) 
+            - lastv[i,j]/(2*dy)*(lastu[i,j+1]-lastu[i,j-1])
             ) +
-            ν * (
-            lastu[i+1,j]-2*lastu[i,j]+ lastu[i-1,j] +
-            (lastu[i,j+1]-2*lastu[i,j]+ lastu[i,j-1])
-            )
-            nextv[i,j] = lastv[i,j]- μ * (
-            lastu[i,j]*(lastv[i,j]-lastv[i-1,j]) -
-            lastv[i,j]*(lastv[i,j]-lastv[i,j-1])
+            μ * (
+            (lastu[i+1,j]-2*lastu[i,j]+ lastu[i-1,j])/dx^2 +
+            (lastu[i,j+1]-2*lastu[i,j]+ lastu[i,j-1])/dy^2
+            ) )
+
+            nextv[i,j] = lastv[i,j] + dt * ( (
+            - lastu[i,j]/(2*dx)*(lastv[i+1,j]-lastv[i-1,j]) 
+            - lastv[i,j]/(2*dy)*(lastv[i,j+1]-lastv[i,j-1])
             ) +
-            ν * (
-            (lastv[i+1,j]-2*lastv[i,j]+ lastv[i-1,j]) +
-            (lastv[i,j+1]-2*lastv[i,j]+ lastv[i,j-1])
-            )
+            μ * (
+            (lastv[i+1,j]-2*lastv[i,j]+ lastv[i-1,j])/dx^2 +
+            (lastv[i,j+1]-2*lastv[i,j]+ lastv[i,j-1])/dy^2
+            ) )
         end
     end
     if get_x(rank, side) == 0


### PR DESCRIPTION
I found a couple weird things with the discretization scheme as it was. It seemed like for the first order derivatives it wasn't a centered finite difference scheme but a one sided scheme, and $\mu$ was supposed to represent $1 / \text{Re}$ but it was multiplying the wrong things, and then just a few other oddities. I also wrote my code as though there exists new variables,

1. dx
2. dy
3. dt 
4. no more $\mu$

To define them I would personally write the scaling lines as 

```julia

scaling = 4

Nx = 100
Ny = 100
tsteps = 1000
Tmax = 10 

μ = 0.1 # 1/Re
#ν = 0.1

dx = scaling / Nx
dy = scaling / Ny
dt = Tmax / tsteps 

```

but I wasn't able to successfully add in these variables to the Burgers structure without breaking something, so I'm not opening a pull request to change burgers.jl....